### PR TITLE
Use Ninja generator and consistent job count in profiles

### DIFF
--- a/profiles/linux_clang15.txt
+++ b/profiles/linux_clang15.txt
@@ -9,3 +9,5 @@ build_type=Release
 [conf]
 tools.build:compiler_executables={"c": "clang", "cpp": "clang++"}
 tools.build:cxxflags=["-stdlib=libc++", "-O2"]
+tools.cmake.cmaketoolchain:generator=Ninja
+tools.build:jobs=8

--- a/profiles/macos_clang14.txt
+++ b/profiles/macos_clang14.txt
@@ -9,3 +9,5 @@ build_type=Release
 [conf]
 tools.apple:sdk=macosx
 tools.build:cxxflags=["-stdlib=libc++"]
+tools.cmake.cmaketoolchain:generator=Ninja
+tools.build:jobs=8

--- a/profiles/windows_msvc17.txt
+++ b/profiles/windows_msvc17.txt
@@ -9,3 +9,5 @@ build_type=Release
 [conf]
 tools.microsoft.msbuild:vs_version=17
 tools.build:cxxflags=["/permissive-"]
+tools.cmake.cmaketoolchain:generator=Ninja
+tools.build:jobs=8


### PR DESCRIPTION
## Summary
- configure Ninja as the CMake generator
- set parallel jobs to 8 for consistent builds across platforms

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b72c950f78832f97e0875d2ed2cfa2