### PR TITLE
Enforce C++17 across platform profiles

### DIFF
--- a/profiles/linux_clang15.txt
+++ b/profiles/linux_clang15.txt
@@ -4,6 +4,7 @@ arch=x86_64
 compiler=clang
 compiler.version=15
 compiler.libcxx=libc++
+compiler.cppstd=17
 build_type=Release
 
 [conf]

--- a/profiles/macos_clang14.txt
+++ b/profiles/macos_clang14.txt
@@ -4,6 +4,7 @@ arch=x86_64
 compiler=clang
 compiler.version=14
 compiler.libcxx=libc++
+compiler.cppstd=17
 build_type=Release
 
 [conf]

--- a/profiles/windows_msvc17.txt
+++ b/profiles/windows_msvc17.txt
@@ -4,6 +4,7 @@ arch=x86_64
 compiler=msvc
 compiler.version=193
 compiler.runtime=dynamic
+compiler.cppstd=17
 build_type=Release
 
 [conf]


### PR DESCRIPTION
## Summary
- specify C++17 standard via `compiler.cppstd=17` for Linux Clang, macOS Clang, and Windows MSVC profiles

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b72c93d228832f8813e6574e35f48a