### PR TITLE
Orchestrate Qt frontend with Python backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,14 +3,19 @@ cmake_minimum_required(VERSION 3.23)
 # Корневой проект без указания языков — он лишь "сценарист"
 project(NAL LANGUAGES NONE)
 
-# Пример шага для Python (по желанию): подготовить окружение Poetry
-# Это "фиктивная" цель, которую можно заставить выполняться раньше GUI.
-# add_custom_target(py_setup ALL
-#   COMMAND poetry install --no-interaction --no-ansi
-#   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-#   COMMENT "Poetry: install deps"
-#   VERBATIM
-# )
+# Все бинарники (бэк и фронт) будут лежать в одной директории
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+# Сборка Python-бэка через Poetry и PyInstaller
+add_custom_target(backend ALL
+    COMMAND poetry install --no-interaction --no-ansi
+    COMMAND poetry run pyinstaller --onefile ${CMAKE_SOURCE_DIR}/src/backend.py --distpath ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    COMMENT "Building Python backend"
+)
 
 # Подключаем C++/Qt часть отдельным подпроектом
 add_subdirectory(gui)
+
+# Гарантируем, что сначала соберётся бэк
+add_dependencies(nal backend)

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -9,8 +9,8 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets)
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets Network)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets Network)
 
 set(PROJECT_SOURCES
         main.cpp
@@ -42,7 +42,7 @@ else()
     endif()
 endif()
 
-target_link_libraries(nal PRIVATE Qt${QT_VERSION_MAJOR}::Widgets)
+target_link_libraries(nal PRIVATE Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Network)
 
 # Qt for iOS sets MACOSX_BUNDLE_GUI_IDENTIFIER automatically since Qt 6.1.
 # If you are developing for iOS or macOS you should consider setting an
@@ -51,6 +51,7 @@ if(${QT_VERSION} VERSION_LESS 6.1.0)
   set(BUNDLE_ID_OPTION MACOSX_BUNDLE_GUI_IDENTIFIER com.example.nal)
 endif()
 set_target_properties(nal PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     ${BUNDLE_ID_OPTION}
     MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
     MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1,14 +1,43 @@
 #include "mainwindow.h"
 #include "./ui_mainwindow.h"
+#include <QCoreApplication>
+#include <QNetworkRequest>
+#include <QJsonDocument>
+#include <QJsonObject>
 
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent)
     , ui(new Ui::MainWindow)
+    , networkManager(new QNetworkAccessManager(this))
 {
     ui->setupUi(this);
+
+    // Запускаем бэкенд в отдельном процессе
+    QString backendPath = QCoreApplication::applicationDirPath() + "/backend";
+    backendProcess.start(backendPath);
 }
 
 MainWindow::~MainWindow()
 {
+    backendProcess.kill();
+    backendProcess.waitForFinished();
     delete ui;
+}
+
+void MainWindow::on_pushButton_clicked()
+{
+    QNetworkRequest request(QUrl("http://127.0.0.1:5000/time"));
+    QNetworkReply *reply = networkManager->get(request);
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() { handleNetworkReply(reply); });
+}
+
+void MainWindow::handleNetworkReply(QNetworkReply *reply)
+{
+    if (reply->error() == QNetworkReply::NoError) {
+        QByteArray data = reply->readAll();
+        QJsonDocument doc = QJsonDocument::fromJson(data);
+        QString time = doc.object().value("time").toString();
+        ui->label->setText(time);
+    }
+    reply->deleteLater();
 }

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -2,6 +2,9 @@
 #define MAINWINDOW_H
 
 #include <QMainWindow>
+#include <QProcess>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
 
 QT_BEGIN_NAMESPACE
 namespace Ui {
@@ -17,7 +20,13 @@ public:
     MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
 
+private slots:
+    void on_pushButton_clicked();
+    void handleNetworkReply(QNetworkReply *reply);
+
 private:
     Ui::MainWindow *ui;
+    QProcess backendProcess;
+    QNetworkAccessManager *networkManager;
 };
 #endif // MAINWINDOW_H

--- a/gui/mainwindow.ui
+++ b/gui/mainwindow.ui
@@ -13,7 +13,27 @@
   <property name="windowTitle">
    <string>MainWindow</string>
   </property>
-  <widget class="QWidget" name="centralwidget"/>
+  <widget class="QWidget" name="centralwidget">
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QPushButton" name="pushButton">
+      <property name="text">
+       <string>Get Time</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>...</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+    </item>
+   </layout>
+  </widget>
   <widget class="QMenuBar" name="menubar">
    <property name="geometry">
     <rect>

--- a/src/backend.py
+++ b/src/backend.py
@@ -1,0 +1,33 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from datetime import datetime
+import json
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/time':
+            now = datetime.now().isoformat()
+            payload = json.dumps({'time': now}).encode()
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.send_header('Content-Length', str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format, *args):
+        # Suppress default console logging
+        pass
+
+def main():
+    server = HTTPServer(('127.0.0.1', 5000), Handler)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- build Python backend with Poetry and PyInstaller from root CMake
- connect Qt GUI to backend via HTTP and display current time
- add network-enabled GUI with button and label

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "QT"...)*
- `poetry run pyinstaller --onefile src/backend.py --distpath /tmp/backend`
- `curl -s http://127.0.0.1:5000/time`


------
https://chatgpt.com/codex/tasks/task_e_68b735a89630832fa4356b47b402b610